### PR TITLE
Updating parser combinators on Struct.hs

### DIFF
--- a/src/Parser/XML/Struct.hs
+++ b/src/Parser/XML/Struct.hs
@@ -67,16 +67,21 @@ parseFeatureData =
 
 parseFeatureName :: Parsec String () String
 parseFeatureName =
-  string "name=\""  >> blanks >>
-  many1 letter     >>= \n -> char '"' >>
+  try (string "name=\"")  >> blanks >>
+  many1 letter >>= \n -> char '"' >>
   return n
 
 
 parseFeatureType :: Parsec String () FeatureType
 parseFeatureType =
-  string "mandatory=\"" >> blanks >>
-  many1 letter >>=
-    \t -> char '"' >> blanks >>
+  option (Optional) (
+    do
+      string "mandatory=\""
+      blanks
+      t <- many1 letter
+      char '"'
+      blanks
       case t of
         "true"  -> return Mandatory
         "false" -> return Optional
+  )

--- a/test/Test/Parser/fm.ide
+++ b/test/Test/Parser/fm.ide
@@ -7,6 +7,10 @@
           <feature mandatory="true" name="receiveMessage"/>
   			</or>
         <feature mandatory="false" name="addressBook"/>
+				<alt name="search">
+					<feature mandatory="true" name="simpleSearch"/>
+					<feature mandatory="true" name="advancedSearch"/>
+				</alt>
         <alt mandatory="true" name="persistence">
           <feature mandatory="true" name="relational"/>
           <feature mandatory="true" name="nonRelational"/>
@@ -14,18 +18,6 @@
       </and>
 		</struct>
 		<constraints>
-			<rule>
-				<eq>
-					<var>sign</var>
-					<var>verify</var>
-				</eq>
-			</rule>
-      <rule>
-				<eq>
-					<var>encrypt</var>
-					<var>decrypt</var>
-				</eq>
-			</rule>
       <rule>
 				<imp>
 					<var>advancedSearch</var>


### PR DESCRIPTION
correction of a minor bug that made the parser fail when the "mandatory" option on XML's weren't specified.

example:

\<alt name="search">
    \<feature mandatory="true" name="simpleSearch"/>
    \<feature mandatory="true" name="advancedSearch"/>
\</alt>